### PR TITLE
ft(view items):A buyer can view one or all items

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "collectCoverageFrom": [
       "src/**/*.js",
       "!src/index.js",
-      "!**/__tests__/**/*.js?(x)"
+      "!**/__tests__/**/*.js?(x)",
+      "!src/modules/**/index.js"
     ],
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/?(*.)(spec|test)js",

--- a/src/modules/buyer/BuyerController.js
+++ b/src/modules/buyer/BuyerController.js
@@ -1,0 +1,18 @@
+import ItemService from '../../services/ItemService';
+
+
+class BuyerController {
+  static async getAllItems(req, res) {
+    try {
+      let { page, size } = req.query;
+      page = page || 1;
+      size = size || 10;
+
+      const items = await ItemService.getSellerItems(undefined, page, size);
+      return res.status(200).json(items);
+    } catch (error) {
+      return res.status(400).json(error.message);
+    }
+  }
+}
+export default BuyerController;

--- a/src/modules/buyer/__tests__/BuyerController.spec.js
+++ b/src/modules/buyer/__tests__/BuyerController.spec.js
@@ -1,0 +1,19 @@
+import BuyerController from '../BuyerController';
+import ItemService from '../../../services/ItemService';
+import item, { response as res } from '../../item/__mocks__/itemMock';
+
+describe('BuyerController', () => {
+  describe('BuyerController.getAllItems', () => {
+    it('should return all items for a buyer to choose', async () => {
+      const req = {
+        query: {
+          page: 1,
+          size: 15
+        }
+      };
+      jest.spyOn(ItemService, 'getSellerItems').mockResolvedValue(item);
+      await BuyerController.getAllItems(req, res);
+      expect(res.status().json).toBeCalledWith(item);
+    });
+  });
+});

--- a/src/modules/buyer/index.js
+++ b/src/modules/buyer/index.js
@@ -1,0 +1,12 @@
+import express from 'express';
+import BuyerController from './BuyerController';
+
+
+const buyerRouter = express.Router();
+
+
+buyerRouter.get(
+  '/buyer/items',
+  BuyerController.getAllItems
+);
+export default buyerRouter;

--- a/src/modules/index.js
+++ b/src/modules/index.js
@@ -1,10 +1,12 @@
 import authenticationRouter from './authentication';
 import itemRouter from './item';
+import buyerRouter from './buyer';
 
 
 const apiPrefix = '/api/v1';
 
 const routes = (app) => {
+  app.use(apiPrefix, buyerRouter);
   app.use(apiPrefix, authenticationRouter);
   app.use(apiPrefix, itemRouter);
   return app;

--- a/src/modules/item/ItemController.js
+++ b/src/modules/item/ItemController.js
@@ -32,5 +32,19 @@ class ItemController {
       return res.status(400).json(error.message);
     }
   }
+
+  static async getOneItem(req, res) {
+    try {
+      let { page, size } = req.query;
+      page = page || 1;
+      size = size || 10;
+      const { itemId } = req.query;
+      const items = await ItemService.getOneItem(itemId, page, size);
+
+      return res.status(200).json(items);
+    } catch (error) {
+      return res.status(400).json(error.message);
+    }
+  }
 }
 export default ItemController;

--- a/src/modules/item/__tests__/ItemController.spec.js
+++ b/src/modules/item/__tests__/ItemController.spec.js
@@ -35,10 +35,6 @@ describe('ItemController', () => {
     });
   });
   describe('ItemController.getAllSellerItems', () => {
-    afterAll(() => {
-      jest.restoreAllMocks();
-      jest.resetAllMocks();
-    });
     it('should get all items for a seller', async () => {
       const req = {
         query: {
@@ -51,6 +47,21 @@ describe('ItemController', () => {
       };
       jest.spyOn(ItemService, 'getSellerItems').mockResolvedValue(item);
       await ItemController.getAllSellerItems(req, res);
+      expect(res.status().json).toBeCalledWith(item);
+    });
+  });
+  describe('ItemController.getOneItem', () => {
+    it('should return one item', async () => {
+      const req = {
+        query: {
+          page: 2,
+          size: 12,
+          itemId: 3
+        }
+      };
+      jest.spyOn(ItemService, 'getOneItem').mockResolvedValue(item);
+      await ItemController.getOneItem(req, res);
+      expect(ItemService.getOneItem).toBeCalledTimes(1);
       expect(res.status().json).toBeCalledWith(item);
     });
   });

--- a/src/modules/item/index.js
+++ b/src/modules/item/index.js
@@ -6,19 +6,23 @@ import ItemValidator from '../../middlewares/ItemValidator';
 
 const itemRouter = express.Router();
 
-itemRouter.use(
-  GeneralValidator.verifyToken,
-  GeneralValidator.verifySeller,
-);
-
 itemRouter.post(
   '/item/add',
+  GeneralValidator.verifyToken,
+  GeneralValidator.verifySeller,
   ItemValidator.validateRequestBody,
   ItemController.createItem
 );
 
 itemRouter.get(
-  '/item',
+  '/items',
+  GeneralValidator.verifyToken,
+  GeneralValidator.verifySeller,
   ItemController.getAllSellerItems
+);
+
+itemRouter.get(
+  '/item',
+  ItemController.getOneItem
 );
 export default itemRouter;

--- a/src/services/__tests__/ItemService.spec.js
+++ b/src/services/__tests__/ItemService.spec.js
@@ -80,4 +80,45 @@ describe('ItemService', () => {
       expect(result.pageData.totalPages).toEqual(2);
     });
   });
+  describe('ItemService.getOneItem', () => {
+    it('should return ony one item', async () => {
+      jest.spyOn(Item, 'findAll').mockResolvedValue([{
+        dataValues: {
+          id: 1,
+          name: 'Gucci bag',
+          description: 'Hand made bags from Italy',
+          price: 20000 - 30000,
+        }
+      }]);
+      jest.spyOn(Image, 'findAll').mockResolvedValue([{
+        id: 2,
+        url: 'www.cloudinary.com',
+        itemId: 8,
+        createdAt: '2019-06-08T06:06:22.562Z',
+        updatedAt: '2019-06-08T06:06:22.562Z'
+      }]);
+      const result = await ItemService.getOneItem(1, 1, 10);
+      expect(Image.findAll).toBeCalled();
+      expect(Item.findAll).toBeCalled();
+      expect(result).toEqual(
+        [{
+          images: [{
+            createdAt: '2019-06-08T06:06:22.562Z',
+            id: 2,
+            itemId: 8,
+            updatedAt: '2019-06-08T06:06:22.562Z',
+            url: 'www.cloudinary.com'
+          }],
+          item: {
+            dataValues: {
+              description: 'Hand made bags from Italy',
+              id: 1,
+              name: 'Gucci bag',
+              price: -10000
+            }
+          }
+        }]
+      );
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?
This PR ensures that a buyer can view one or all items in the store
#### Description of Task to be completed?
- [x] A buyer can view one or more items from the store
#### How should this be manually tested?
- git pull `ft-buyer-view-all-items-166381289`
- Test the endpoints in the screenshot below using Postman
#### What are the relevant pivotal tracker stories?
[#166381289]
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/40671517/59257958-b50f0700-8c3f-11e9-8e41-7b044b3ab35d.png)


